### PR TITLE
Drain timeout fix

### DIFF
--- a/chanx/core/testing.py
+++ b/chanx/core/testing.py
@@ -31,6 +31,21 @@ from chanx.core.config import config
 from chanx.core.websocket import ChanxWebsocketConsumerMixin
 from chanx.messages.base import BaseMessage
 
+INNER_RECEIVE_MARGIN = 5
+"""Seconds by which a collection's inner receive outlives the collection itself.
+
+``receive_all_json`` and ``receive_all_messages`` wrap their own timeout around
+``receive_json_from``. Handing the inner receive the same value puts both
+deadlines in the same event-loop iteration, so a late wake-up - a loaded test
+suite is enough - expires them together. asgiref reacts to the inner one by
+cancelling the ASGI application task
+(``ApplicationCommunicator.receive_output``), which kills the connection: the
+collection still returns what it had, but every later send on that
+communicator raises ``CancelledError`` from a stack that says nothing about
+why. Giving the inner receive a later deadline keeps the collection's own
+timeout the one that fires.
+"""
+
 
 @dataclass
 class CapturedTopicBroadcast:
@@ -205,7 +220,9 @@ class WebsocketCommunicatorMixin:
         try:
             async with async_timeout(timeout):
                 while True:
-                    raw_message = await self.receive_json_from(timeout)
+                    raw_message = await self.receive_json_from(
+                        timeout + INNER_RECEIVE_MARGIN
+                    )
                     json_list.append(raw_message)
         except (asyncio.CancelledError, asyncio.TimeoutError):
             pass
@@ -237,7 +254,9 @@ class WebsocketCommunicatorMixin:
         try:
             async with async_timeout(timeout):
                 while True:
-                    raw_message = await self.receive_json_from(timeout)
+                    raw_message = await self.receive_json_from(
+                        timeout + INNER_RECEIVE_MARGIN
+                    )
 
                     if self._should_camelize:
                         raw_message = humps.decamelize(raw_message)

--- a/tests/ext/fast_channels/test_drain_timeout.py
+++ b/tests/ext/fast_channels/test_drain_timeout.py
@@ -1,0 +1,56 @@
+"""A message collection that ends in a timeout must leave the socket usable."""
+
+import asyncio
+import time
+from typing import Literal
+
+import pytest
+from chanx.core.decorators import ws_handler
+from chanx.fast_channels.testing import WebsocketCommunicator
+from chanx.fast_channels.websocket import AsyncJsonWebsocketConsumer
+from chanx.messages.base import BaseMessage
+from fastapi import FastAPI
+
+
+class EchoReq(BaseMessage):
+    action: Literal["drain_echo"] = "drain_echo"
+    payload: str
+
+
+class EchoRes(BaseMessage):
+    action: Literal["drain_echo_res"] = "drain_echo_res"
+    payload: str
+
+
+class QuietConsumer(AsyncJsonWebsocketConsumer):
+    """Sends nothing until asked, so a collection has to run out its timeout."""
+
+    send_completion = True
+
+    @ws_handler
+    async def handle_echo(self, message: EchoReq) -> EchoRes:
+        return EchoRes(payload=message.payload)
+
+
+app = FastAPI()
+app.add_websocket_route("/ws/quiet", QuietConsumer.as_asgi())
+
+
+@pytest.mark.asyncio
+async def test_collection_timeout_leaves_the_connection_alive() -> None:
+    """The inner receive must not expire first and cancel the application task.
+
+    The event loop is blocked so that it wakes up past both the collection's
+    deadline and the inner receive's. Without a margin between the two the
+    inner one expires as well, asgiref cancels the ASGI application task, and
+    the send below raises CancelledError.
+    """
+    async with WebsocketCommunicator(app, "/ws/quiet", consumer=QuietConsumer) as comm:
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.45, lambda: time.sleep(0.2))
+
+        assert await comm.receive_all_messages(timeout=0.5) == []
+        assert not comm.future.cancelled()
+
+        await comm.send_message(EchoReq(payload="still here"))
+        assert await comm.receive_all_messages() == [EchoRes(payload="still here")]


### PR DESCRIPTION
Hi!
I've noticed that tests run very slow sometimes, and sometimes fail without explanation. I put an agent on investigating this. Essentially what's in the comment:


``receive_all_json`` and ``receive_all_messages`` wrap their own timeout around
``receive_json_from``. Handing the inner receive the same value puts both
deadlines in the same event-loop iteration, so a late wake-up - a loaded test
suite is enough - expires them together. asgiref reacts to the inner one by
cancelling the ASGI application task
(``ApplicationCommunicator.receive_output``), which kills the connection: the
collection still returns what it had, but every later send on that
communicator raises ``CancelledError`` from a stack that says nothing about
why. Giving the inner receive a later deadline keeps the collection's own
timeout the one that fires.


Hope this helps all the best!
